### PR TITLE
feat: Add author profile section below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+import { AuthorProfile } from 'app/components/author-profile'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -79,7 +80,7 @@ export default async function Blog({ params }) {
             url: `${baseUrl}/blog/${post.slug}`,
             author: {
               '@type': 'Person',
-              name: 'My Portfolio',
+              name: post.metadata.author || 'My Portfolio',
             },
           }),
         }}
@@ -95,6 +96,12 @@ export default async function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        author={post.metadata.author}
+        authorBio={post.metadata.authorBio}
+        authorImage={post.metadata.authorImage}
+        authorUrl={post.metadata.authorUrl}
+      />
     </section>
   )
 }

--- a/app/blog/posts/spaces-vs-tabs.mdx
+++ b/app/blog/posts/spaces-vs-tabs.mdx
@@ -2,6 +2,8 @@
 title: 'Spaces vs. Tabs: The Indentation Debate Continues'
 publishedAt: '2024-04-08'
 summary: 'Explore the enduring debate between using spaces and tabs for code indentation, and why this choice matters more than you might think.'
+author: 'Min Sung'
+authorBio: 'Software engineer passionate about clean code, efficient workflows, and modern web development.'
 ---
 
 The debate between using spaces and tabs for indentation in coding may seem trivial to the uninitiated, but it is a topic that continues to inspire passionate discussions among developers. This seemingly minor choice can affect code readability, maintenance, and even team dynamics.

--- a/app/blog/posts/static-typing.mdx
+++ b/app/blog/posts/static-typing.mdx
@@ -2,6 +2,8 @@
 title: 'The Power of Static Typing in Programming'
 publishedAt: '2024-04-07'
 summary: 'In the ever-evolving landscape of software development, the debate between dynamic and static typing continues to be a hot topic.'
+author: 'Min Sung'
+authorBio: 'Software engineer passionate about clean code, efficient workflows, and modern web development.'
 ---
 
 In the ever-evolving landscape of software development, the debate between dynamic and static typing continues to be a hot topic. While dynamic typing offers flexibility and rapid development, static typing brings its own set of powerful advantages that can significantly improve the quality and maintainability of code. In this post, we'll explore why static typing is crucial for developers, accompanied by practical examples through markdown code snippets.

--- a/app/blog/posts/vim.mdx
+++ b/app/blog/posts/vim.mdx
@@ -2,6 +2,8 @@
 title: 'Embracing Vim: The Unsung Hero of Code Editors'
 publishedAt: '2024-04-09'
 summary: 'Discover why Vim, with its steep learning curve, remains a beloved tool among developers for editing code efficiently and effectively.'
+author: 'Min Sung'
+authorBio: 'Software engineer passionate about clean code, efficient workflows, and modern web development.'
 ---
 
 In the world of software development, where the latest and greatest tools frequently capture the spotlight, Vim stands out as a timeless classic. Despite its age and initial complexity, Vim has managed to retain a devoted following of developers who swear by its efficiency, versatility, and power.

--- a/app/blog/utils.ts
+++ b/app/blog/utils.ts
@@ -6,6 +6,10 @@ type Metadata = {
   publishedAt: string
   summary: string
   image?: string
+  author?: string
+  authorBio?: string
+  authorImage?: string
+  authorUrl?: string
 }
 
 function parseFrontmatter(fileContent: string) {

--- a/app/components/author-profile.tsx
+++ b/app/components/author-profile.tsx
@@ -48,11 +48,11 @@ export function AuthorProfile({
                 rel="noopener noreferrer"
                 className="text-lg font-medium text-neutral-900 dark:text-neutral-100 hover:text-neutral-600 dark:hover:text-neutral-400 transition-colors"
               >
-                {author}
+                {author} Sir
               </Link>
             ) : (
               <h3 className="text-lg font-medium text-neutral-900 dark:text-neutral-100">
-                {author}
+                {author} Sir
               </h3>
             )}
           </div>

--- a/app/components/author-profile.tsx
+++ b/app/components/author-profile.tsx
@@ -1,0 +1,68 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+interface AuthorProfileProps {
+  author?: string
+  authorBio?: string
+  authorImage?: string
+  authorUrl?: string
+}
+
+export function AuthorProfile({
+  author,
+  authorBio,
+  authorImage,
+  authorUrl,
+}: AuthorProfileProps) {
+  if (!author) {
+    return null
+  }
+
+  return (
+    <div className="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-800">
+      <div className="flex items-start gap-4">
+        {authorImage && (
+          <div className="flex-shrink-0">
+            <Image
+              src={authorImage}
+              alt={author}
+              width={64}
+              height={64}
+              className="rounded-full"
+            />
+          </div>
+        )}
+        {!authorImage && (
+          <div className="flex-shrink-0 w-16 h-16 rounded-full bg-neutral-200 dark:bg-neutral-800 flex items-center justify-center">
+            <span className="text-2xl font-medium text-neutral-600 dark:text-neutral-400">
+              {author.charAt(0).toUpperCase()}
+            </span>
+          </div>
+        )}
+        <div className="flex-grow min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            {authorUrl ? (
+              <Link
+                href={authorUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-lg font-medium text-neutral-900 dark:text-neutral-100 hover:text-neutral-600 dark:hover:text-neutral-400 transition-colors"
+              >
+                {author}
+              </Link>
+            ) : (
+              <h3 className="text-lg font-medium text-neutral-900 dark:text-neutral-100">
+                {author}
+              </h3>
+            )}
+          </div>
+          {authorBio && (
+            <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed">
+              {authorBio}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Implement author profile display at the end of blog posts to give readers
a more personal connection with the content. This feature allows each post
to showcase the author's name, bio, avatar image, and website link.

Changes:
- Extend Metadata type with author fields (author, authorBio, authorImage, authorUrl)
- Create AuthorProfile component with dark mode and responsive design
- Integrate AuthorProfile component into blog post detail page
- Update JSON-LD structured data to use dynamic author metadata
- Add author information to existing 3 blog posts (vim, static-typing, spaces-vs-tabs)

The component gracefully handles missing author data and automatically
generates initial-based avatars when no image is provided.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>